### PR TITLE
bug: Reduce GitHub Actions Inputs by consolidating event and venue information

### DIFF
--- a/.github/workflows/create-event.yml
+++ b/.github/workflows/create-event.yml
@@ -19,20 +19,12 @@ on:
         description: 'Event description'
         required: true
         type: string
-      event_date:
-        description: 'Event date (YYYY-MM-DD)'
+      event_datetime:
+        description: 'Event date and time (YYYY-MM-DD HH:MM format)'
         required: true
         type: string
-      event_time:
-        description: 'Event time (HH:MM in 24h format)'
-        required: true
-        type: string
-      venue:
-        description: 'Venue name'
-        required: true
-        type: string
-      venue_address:
-        description: 'Venue address'
+      venue_info:
+        description: 'Venue name and address (separate with | e.g. "Tech Hub|123 Main St")'
         required: true
         type: string
       num_speakers:
@@ -94,10 +86,8 @@ jobs:
         EVENT_TYPE: ${{ github.event.inputs.event_type }}
         EVENT_TITLE: ${{ github.event.inputs.event_title }}
         EVENT_DESCRIPTION: ${{ github.event.inputs.event_description }}
-        EVENT_DATE: ${{ github.event.inputs.event_date }}
-        EVENT_TIME: ${{ github.event.inputs.event_time }}
-        VENUE: ${{ github.event.inputs.venue }}
-        VENUE_ADDRESS: ${{ github.event.inputs.venue_address }}
+        EVENT_DATETIME: ${{ github.event.inputs.event_datetime }}
+        VENUE_INFO: ${{ github.event.inputs.venue_info }}
         NUM_SPEAKERS: ${{ github.event.inputs.num_speakers }}
         SPONSOR: ${{ github.event.inputs.sponsor }}
         SPONSOR_URL: ${{ github.event.inputs.sponsor_url }}


### PR DESCRIPTION
This pull request refactors how event date/time and venue information are handled, both in the GitHub Actions workflow and in the Go configuration code. The changes consolidate separate fields for date, time, venue, and venue address into combined fields, simplifying input and parsing logic.

**Workflow input and environment variable changes:**

* Replaced separate `event_date` and `event_time` inputs with a single `event_datetime` input, and combined `venue` and `venue_address` into a single `venue_info` input in `.github/workflows/create-event.yml`.
* Updated environment variable references in the workflow to use `EVENT_DATETIME` and `VENUE_INFO` instead of the previous separate variables.

**Go configuration parsing improvements:**

* Updated `pkg/config/config.go` to parse the new combined `EVENT_DATETIME` and `VENUE_INFO` environment variables, falling back to the old separate variables if needed. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R82-R85) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R174-R203)
* Refactored the `Config` struct initialization to use the parsed date, time, venue, and address values from the new parsing functions.